### PR TITLE
Strix HALO trim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ build/
 compile_commands.json
 
 install/
+dist/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Example of cmake for integration with project [examples/CMakeLists.txt](examples
 
 Full project may be found in `example` directory.
 
+### Environment variables
+
+* `MEMPULSE_TRIM_VISIBLE_MEMORY` - optional soft cap for reported local/dedicated memory.
+    Useful for experiments that intentionally avoid allocating close to the full visible budget.
+    Accepts raw bytes or units like `56GiB`, `60GB`, `1024MiB`.
+
 
 ```cpp
 #include "mempulse/mempulse.h"

--- a/mempulse/mempulse.cpp
+++ b/mempulse/mempulse.cpp
@@ -7,7 +7,126 @@
 #include "SafeCall.h"
 #include "Logging.h"
 
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <limits>
+#include <optional>
+#include <string>
+
 using namespace mempulse;
+
+namespace {
+
+std::optional<unsigned long long> parse_memory_bytes(std::string value) {
+	value.erase(std::remove_if(value.begin(), value.end(), [](unsigned char ch) {
+		return std::isspace(ch) != 0;
+	}), value.end());
+
+	if (value.empty())
+		return std::nullopt;
+
+	std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+		return static_cast<char>(std::tolower(ch));
+	});
+
+	std::size_t split = 0;
+	while (split < value.size() && std::isdigit(static_cast<unsigned char>(value[split])) != 0)
+		++split;
+
+	if (split == 0)
+		return std::nullopt;
+
+	unsigned long long base = 0;
+	try {
+		base = static_cast<unsigned long long>(std::stoull(value.substr(0, split)));
+	} catch (...) {
+		return std::nullopt;
+	}
+
+	const std::string unit = value.substr(split);
+	unsigned long long multiplier = 1ULL;
+	if (unit.empty() || unit == "b") {
+		multiplier = 1ULL;
+	} else if (unit == "kb") {
+		multiplier = 1000ULL;
+	} else if (unit == "mb") {
+		multiplier = 1000ULL * 1000ULL;
+	} else if (unit == "gb") {
+		multiplier = 1000ULL * 1000ULL * 1000ULL;
+	} else if (unit == "kib") {
+		multiplier = 1024ULL;
+	} else if (unit == "mib") {
+		multiplier = 1024ULL * 1024ULL;
+	} else if (unit == "gib") {
+		multiplier = 1024ULL * 1024ULL * 1024ULL;
+	} else if (unit == "tb") {
+		multiplier = 1000ULL * 1000ULL * 1000ULL * 1000ULL;
+	} else if (unit == "tib") {
+		multiplier = 1024ULL * 1024ULL * 1024ULL * 1024ULL;
+	} else {
+		return std::nullopt;
+	}
+
+	if (base > std::numeric_limits<unsigned long long>::max() / multiplier)
+		return std::nullopt;
+
+	return base * multiplier;
+}
+
+std::optional<unsigned long long> get_trim_visible_memory_limit() {
+	std::string value;
+#ifdef _WIN32
+	char* raw = nullptr;
+	size_t len = 0;
+	errno_t rc = _dupenv_s(&raw, &len, "MEMPULSE_TRIM_VISIBLE_MEMORY");
+	if (rc != 0 || raw == nullptr)
+		return std::nullopt;
+
+	value.assign(raw);
+	free(raw);
+#else
+	const char* raw = std::getenv("MEMPULSE_TRIM_VISIBLE_MEMORY");
+	if (!raw)
+		return std::nullopt;
+	value.assign(raw);
+#endif
+
+	if (value.empty())
+		return std::nullopt;
+
+	return parse_memory_bytes(value);
+}
+
+void apply_trim_visible_memory(MempulseDeviceMemoryInfo& info) {
+	auto trimVisibleMemory = get_trim_visible_memory_limit();
+	if (!trimVisibleMemory.has_value())
+		return;
+
+	const unsigned long long limit = trimVisibleMemory.value();
+	if (info.dedicatedTotal <= limit)
+		return;
+
+	info.dedicatedTotal = limit;
+	if (info.dedicatedUsed > info.dedicatedTotal)
+		info.dedicatedUsed = info.dedicatedTotal;
+}
+
+void apply_trim_visible_memory(MempulseDeviceMemoryUsage& usage) {
+	auto trimVisibleMemory = get_trim_visible_memory_limit();
+	if (!trimVisibleMemory.has_value())
+		return;
+
+	const unsigned long long limit = trimVisibleMemory.value();
+	if (usage.total <= limit)
+		return;
+
+	const unsigned long long used = usage.total > usage.free ? usage.total - usage.free : 0ULL;
+	usage.total = limit;
+	usage.free = used >= usage.total ? 0ULL : usage.total - used;
+}
+
+} // namespace
 
 MempulseError MempulseInitialize(MempulseContext* context, MempulseBackend backend) {
 	MEMPULSE_LOG_TRACE();
@@ -112,7 +231,9 @@ MempulseError MempulseGetDeviceMemoryInfo(
 		if (!device)
 			throw ErrorInvalidDevice(deviceIndex);
 
-		*deviceMemoryInfo = device->GetMemoryInfo();
+		auto info = device->GetMemoryInfo();
+		apply_trim_visible_memory(info);
+		*deviceMemoryInfo = info;
 	});
 	check(result);
 
@@ -136,7 +257,9 @@ MEMPULSE_API MempulseError MempulseGetDeviceMemoryUsage(
 		if (!device)
 			throw ErrorInvalidDevice(deviceIndex);
 
-		*deviceMemoryUsage = device->GetMemoryUsage();
+		auto usage = device->GetMemoryUsage();
+		apply_trim_visible_memory(usage);
+		*deviceMemoryUsage = usage;
 	});
 	check(result);
 

--- a/tests/TestDevice.cpp
+++ b/tests/TestDevice.cpp
@@ -1,6 +1,72 @@
 #include <gtest/gtest.h>
 #include "mempulse/mempulse.h"
 
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace {
+
+class ScopedEnvVar {
+public:
+	ScopedEnvVar(const char* name, const std::string& value)
+		: m_name(name), m_hadOriginal(false) {
+		loadCurrentValue();
+
+		set(value.c_str());
+	}
+
+	~ScopedEnvVar() {
+		if (m_hadOriginal)
+			set(m_original.c_str());
+		else
+			unset();
+	}
+
+private:
+	void loadCurrentValue() {
+#ifdef _WIN32
+		char* raw = nullptr;
+		size_t len = 0;
+		errno_t rc = _dupenv_s(&raw, &len, m_name.c_str());
+		if (rc == 0 && raw != nullptr) {
+			m_hadOriginal = true;
+			m_original = raw;
+			free(raw);
+		}
+#else
+		const char* current = std::getenv(m_name.c_str());
+		if (current != nullptr) {
+			m_hadOriginal = true;
+			m_original = current;
+		}
+#endif
+	}
+
+	void set(const char* value) {
+#ifdef _WIN32
+		_putenv_s(m_name.c_str(), value);
+#else
+		setenv(m_name.c_str(), value, 1);
+#endif
+	}
+
+	void unset() {
+#ifdef _WIN32
+		_putenv_s(m_name.c_str(), "");
+#else
+		unsetenv(m_name.c_str());
+#endif
+	}
+
+	std::string m_name;
+	std::string m_original;
+	bool m_hadOriginal;
+};
+
+} // namespace
+
 struct TestDevice : public ::testing::TestWithParam<MempulseBackend> {
 	void SetUp() {
 		MempulseError err;
@@ -87,6 +153,108 @@ TEST_P(TestDevice, get_memory_usage_device_0) {
 	EXPECT_EQ(err, MEMPULSE_SUCCESS);
 	EXPECT_GT(usage.free, 0);
 	EXPECT_GT(usage.total, 0);
+}
+
+TEST_P(TestDevice, trim_visible_memory_caps_reported_totals) {
+	MempulseError err;
+
+	int deviceCount;
+	err = MempulseGetAvailabeDeviceCount(context, &deviceCount);
+	ASSERT_EQ(err, MEMPULSE_SUCCESS);
+	ASSERT_GT(deviceCount, 0);
+
+	MempulseDeviceMemoryInfo baseInfo;
+	err = MempulseGetDeviceMemoryInfo(context, 0, &baseInfo);
+	ASSERT_EQ(err, MEMPULSE_SUCCESS);
+	ASSERT_GT(baseInfo.dedicatedTotal, 0ULL);
+
+	MempulseDeviceMemoryUsage baseUsage;
+	err = MempulseGetDeviceMemoryUsage(context, 0, &baseUsage);
+	ASSERT_EQ(err, MEMPULSE_SUCCESS);
+	ASSERT_GT(baseUsage.total, 0ULL);
+
+	std::cout << "[trim-test] base info: dedicatedUsed=" << baseInfo.dedicatedUsed
+			  << " dedicatedTotal=" << baseInfo.dedicatedTotal
+			  << " sharedUsed=" << baseInfo.sharedUsed
+			  << " sharedTotal=" << baseInfo.sharedTotal << std::endl;
+	std::cout << "[trim-test] base usage: free=" << baseUsage.free
+			  << " total=" << baseUsage.total << std::endl;
+
+	const unsigned long long cap = (baseInfo.dedicatedTotal > (64ULL * 1024ULL * 1024ULL))
+		? (baseInfo.dedicatedTotal - (64ULL * 1024ULL * 1024ULL))
+		: baseInfo.dedicatedTotal;
+	ASSERT_GT(cap, 0ULL);
+	std::cout << "[trim-test] cap=" << cap << std::endl;
+
+	ScopedEnvVar capEnv("MEMPULSE_TRIM_VISIBLE_MEMORY", std::to_string(cap));
+
+	MempulseDeviceMemoryInfo cappedInfo;
+	err = MempulseGetDeviceMemoryInfo(context, 0, &cappedInfo);
+	ASSERT_EQ(err, MEMPULSE_SUCCESS);
+
+	MempulseDeviceMemoryUsage cappedUsage;
+	err = MempulseGetDeviceMemoryUsage(context, 0, &cappedUsage);
+	ASSERT_EQ(err, MEMPULSE_SUCCESS);
+
+	std::cout << "[trim-test] capped info: dedicatedUsed=" << cappedInfo.dedicatedUsed
+			  << " dedicatedTotal=" << cappedInfo.dedicatedTotal
+			  << " sharedUsed=" << cappedInfo.sharedUsed
+			  << " sharedTotal=" << cappedInfo.sharedTotal << std::endl;
+	std::cout << "[trim-test] capped usage: free=" << cappedUsage.free
+			  << " total=" << cappedUsage.total << std::endl;
+
+	EXPECT_EQ(cappedInfo.dedicatedTotal, std::min(baseInfo.dedicatedTotal, cap));
+	EXPECT_EQ(cappedUsage.total, std::min(baseUsage.total, cap));
+	EXPECT_LE(cappedUsage.free, cappedUsage.total);
+	EXPECT_LE(cappedInfo.dedicatedUsed, cappedInfo.dedicatedTotal);
+}
+
+TEST_P(TestDevice, trim_visible_memory_to_24gb) {
+	MempulseError err;
+
+	int deviceCount;
+	err = MempulseGetAvailabeDeviceCount(context, &deviceCount);
+	ASSERT_EQ(err, MEMPULSE_SUCCESS);
+	ASSERT_GT(deviceCount, 0);
+
+	MempulseDeviceMemoryInfo baseInfo;
+	err = MempulseGetDeviceMemoryInfo(context, 0, &baseInfo);
+	ASSERT_EQ(err, MEMPULSE_SUCCESS);
+
+	MempulseDeviceMemoryUsage baseUsage;
+	err = MempulseGetDeviceMemoryUsage(context, 0, &baseUsage);
+	ASSERT_EQ(err, MEMPULSE_SUCCESS);
+
+	std::cout << "[trim-test-24gb] base info: dedicatedUsed=" << baseInfo.dedicatedUsed
+			  << " dedicatedTotal=" << baseInfo.dedicatedTotal
+			  << " sharedUsed=" << baseInfo.sharedUsed
+			  << " sharedTotal=" << baseInfo.sharedTotal << std::endl;
+	std::cout << "[trim-test-24gb] base usage: free=" << baseUsage.free
+			  << " total=" << baseUsage.total << std::endl;
+
+	const unsigned long long cap = 24ULL * 1000ULL * 1000ULL * 1000ULL;
+	std::cout << "[trim-test-24gb] cap=" << cap << std::endl;
+	ScopedEnvVar capEnv("MEMPULSE_TRIM_VISIBLE_MEMORY", std::to_string(cap));
+
+	MempulseDeviceMemoryInfo cappedInfo;
+	err = MempulseGetDeviceMemoryInfo(context, 0, &cappedInfo);
+	ASSERT_EQ(err, MEMPULSE_SUCCESS);
+
+	MempulseDeviceMemoryUsage cappedUsage;
+	err = MempulseGetDeviceMemoryUsage(context, 0, &cappedUsage);
+	ASSERT_EQ(err, MEMPULSE_SUCCESS);
+
+	std::cout << "[trim-test-24gb] capped info: dedicatedUsed=" << cappedInfo.dedicatedUsed
+			  << " dedicatedTotal=" << cappedInfo.dedicatedTotal
+			  << " sharedUsed=" << cappedInfo.sharedUsed
+			  << " sharedTotal=" << cappedInfo.sharedTotal << std::endl;
+	std::cout << "[trim-test-24gb] capped usage: free=" << cappedUsage.free
+			  << " total=" << cappedUsage.total << std::endl;
+
+	EXPECT_EQ(cappedInfo.dedicatedTotal, std::min(baseInfo.dedicatedTotal, cap));
+	EXPECT_EQ(cappedUsage.total, std::min(baseUsage.total, cap));
+	EXPECT_LE(cappedInfo.dedicatedUsed, cappedInfo.dedicatedTotal);
+	EXPECT_LE(cappedUsage.free, cappedUsage.total);
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
* `MEMPULSE_TRIM_VISIBLE_MEMORY` - optional soft cap for reported local/dedicated memory.
* Useful for experiments that intentionally avoid allocating close to the full visible budget.
* Accepts raw bytes or units like `56GiB`, `60GB`, `1024MiB`.
